### PR TITLE
chores: use postgis version 3.x

### DIFF
--- a/PostGIS/update.sh
+++ b/PostGIS/update.sh
@@ -35,6 +35,7 @@ fetch_postgres_image_version() {
 	curl -SsL "https://registry.hub.docker.com/v2/repositories/postgis/postgis/tags/?name=${suite}&ordering=last_updated&" | \
 	  jq -c ".results[] | select( .name | match(\"^${suite}-[0-9.]+$\"))" | \
 	  jq -r ".${item}" | \
+	  sort -r | \
 	  head -n1
 }
 


### PR DESCRIPTION
use postgis version 3.x from base image 

Closes https://github.com/cloudnative-pg/postgres-containers/issues/13 
Signed-off-by: Tao Li <tao.li@enterprisedb.com>