### PR TITLE
feat: Include PostGIS version inside image tags

### DIFF
--- a/.github/generate-strategy.sh
+++ b/.github/generate-strategy.sh
@@ -46,9 +46,9 @@ for version in "${postgis_versions[@]}"; do
 	releaseVersion=$(jq -r '.IMAGE_RELEASE_VERSION' "${versionFile}")
 
 	# Initial aliases are:
-	# "major version"
+	# "major version" (of postgres)
 	# "optional alias"
-	# "major version - postgis version"
+	# "major version - postgis version" ("postgis version": "$postgisMajorVersion.$postgisMinorVersion")
 	# "major version - postgis version - release version"
 	# i.e. "14", "latest", "14-3.2", "14-3.2-1"
 	versionAliases=(

--- a/.github/generate-strategy.sh
+++ b/.github/generate-strategy.sh
@@ -42,24 +42,28 @@ for version in "${postgis_versions[@]}"; do
 
 	# Read versions from the definition file
 	versionFile="${version}/.versions.json"
-	postgisImageVersion=$(jq -r '.POSTGIS_IMAGE_VERSION | split("-") | .[0]' "${versionFile}")
+	postgisVersion=$(jq -r '.POSTGIS_IMAGE_VERSION | split("-") | .[1]' "${versionFile}")
 	releaseVersion=$(jq -r '.IMAGE_RELEASE_VERSION' "${versionFile}")
 
-	# Initial aliases are "major version", "optional alias", "full version with release"
-	# i.e. "14", "latest", "14.2-1", "14.2-postgis","14.2"
+	# Initial aliases are:
+	# "major version"
+	# "optional alias"
+	# "major version - postgis version"
+	# "major version - postgis version - release version"
+	# i.e. "14", "latest", "14-3.2", "14-3.2-1"
 	versionAliases=(
 			"${version}"
 			${aliases[$version]:+"${aliases[$version]}"}
-			"${postgisImageVersion}-${releaseVersion}"
-			"${postgisImageVersion}-postgis"
+			"${version}-${postgisVersion}"
+			"${version}-${postgisVersion}-${releaseVersion}"
 		)
 
-  # Support platform for container images
+	# Support platform for container images
 	platforms="linux/amd64,linux/arm64"
 
 	# Build the json entry
 	entries+=(
-		"{\"name\": \"PostGIS ${postgisImageVersion}\", \"platforms\": \"$platforms\", \"dir\": \"PostGIS/$version\", \"file\": \"PostGIS/$version/Dockerfile\", \"version\": \"$version\", \"tags\": [\"$(join "\", \"" "${versionAliases[@]}")\"]}"
+		"{\"name\": \"PostGIS ${version}-${postgisVersion}\", \"platforms\": \"$platforms\", \"dir\": \"PostGIS/$version\", \"file\": \"PostGIS/$version/Dockerfile\", \"version\": \"$version\", \"tags\": [\"$(join "\", \"" "${versionAliases[@]}")\"]}"
 	)
 done
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ metadata:
   name: cluster-example
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgis:14-3
+  imageName: ghcr.io/cloudnative-pg/postgis:14-3.2
   bootstrap:
     initdb:
       postInitTemplateSQL:


### PR DESCRIPTION
Expose the PostGIS version in the image tags.
Remove the `$version-postgis` tag which is redundant with the image name, plus this repo is dedicated to postgis images only.

Tags are the now the following ones:
~~~
Major Version only: "14"
Optional alias: "latest"
Major version - PostGIS version: "14-3.2"
Major version - PostGIS version - Release version: "14-3.2-1"
~~~

Closes #9
Signed-off-by: Niccolò Fei <niccolo.fei@enterprisedb.com>