### PR TITLE
chore: drop arm64 architecture

### DIFF
--- a/.github/generate-strategy.sh
+++ b/.github/generate-strategy.sh
@@ -61,7 +61,7 @@ for version in "${postgis_versions[@]}"; do
 		)
 
 	# Support platform for container images
-	platforms="linux/amd64,linux/arm64"
+	platforms="linux/amd64"
 
 	# Build the json entry
 	entries+=(


### PR DESCRIPTION
Avoid building for arm64 given that PostGIS community images we are using as a base are currently not built for arm64. Supported will be reintroduced once community arm64 images will be available (https://github.com/postgis/docker-postgis/issues/216).