### PR TITLE
ci: temporary workaround for the snyk failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,7 @@ jobs:
 
     - name: Upload result to GitHub Code Scanning
       uses: github/codeql-action/upload-sarif@v3
+      continue-on-error: true
       with:
         sarif_file: snyk.sarif
 


### PR DESCRIPTION
The Sarif upload action is currently failing because of https://github.com/github/codeql-action/issues/2187, which turned out being related to how snyk produces the sarif.
While the issue is being investigated with snyk, let's deploy a temporary workaround to allow the push of new images.