### PR TITLE
ci: pin pip version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -30,7 +30,8 @@ jobs:
           max_attempts: 3
           command: |
             # pip-tools provides pip-compile used by update.sh
-            pip3 install --upgrade pip-tools pip
+            # TODO: Pinning pip due to https://github.com/jazzband/pip-tools/issues/2176, remove when fixed
+            pip3 install --upgrade pip-tools pip\<25.1
             export PATH=$HOME/.local/bin:$PATH
             echo "Updating PostGIS images"
             ./PostGIS/update.sh

--- a/PostGIS/update.sh
+++ b/PostGIS/update.sh
@@ -17,6 +17,21 @@
 
 set -Eeuo pipefail
 
+error_trap() {
+  local exit_code=$?
+  local line_number=$LINENO
+  local script_name=$(basename "$0")
+  local func_name=${FUNCNAME[1]:-MAIN}
+
+  echo "❌ ERROR in $script_name at line $line_number"
+  echo "   Function: $func_name"
+  echo "   Command: '$BASH_COMMAND'"
+  echo "   Exit code: $exit_code"
+  exit $exit_code
+}
+
+trap error_trap ERR
+
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
 versions=("$@")


### PR DESCRIPTION
pip-compile fails using pip>=25.1, breaking the update. Additionally, add a trap as we did in the wake of the original issue in https://github.com/cloudnative-pg/postgres-containers/issues/169.