### PR TITLE
build: halt build if PG can have a minor upgrade

### DIFF
--- a/PostGIS/Dockerfile.template
+++ b/PostGIS/Dockerfile.template
@@ -31,6 +31,11 @@ COPY requirements.txt /
 # Install additional extensions
 RUN set -xe; \
 	apt-get update; \
+	if apt list --upgradable 2>/dev/null | grep -q '^postgres'; then \
+		echo "ERROR: Upgradable postgres packages found!"; \
+		apt list --upgradable 2>/dev/null | grep '^postgres'; \
+		exit 1; \
+	fi; \
 	apt-get install -y --no-install-recommends \
 		"postgresql-${PG_MAJOR}-pgaudit" \
 		"postgresql-${PG_MAJOR}-pg-failover-slots" \


### PR DESCRIPTION
When building the image, we start from a PostGIS community image. There is a chance that newer PostgreSQL packages are released after image release, and they could be upgraded installing extensions. We want to prevent this scenario, as it could lead to unexpected versions in the container image.

Closes #75