### PR TITLE
Potential fix for code scanning alert no. 257: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,9 @@ jobs:
     name: Generate ClusterImageCatalog
     runs-on: ubuntu-22.04
     needs: build
+    permissions:
+      contents: write
+      actions: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/cloudnative-pg/postgis-containers/security/code-scanning/257](https://github.com/cloudnative-pg/postgis-containers/security/code-scanning/257)

To fix the issue, we will add a `permissions` block to the `image-catalog` job. This block will explicitly define the minimal permissions required for the job to function correctly. Based on the operations performed in the job:
- `contents: write` is needed to push updates to the repository.
- `actions: read` is required to download artifacts.
- `contents: read` is needed to read repository files.

The `permissions` block will be added at the job level to limit its scope to the `image-catalog` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
