### PR TITLE
chore: update requirements.txt every time

### DIFF
--- a/PostGIS/update.sh
+++ b/PostGIS/update.sh
@@ -194,7 +194,7 @@ update_requirements() {
 
 	# This will take the requirements.in file and generate a file
 	# requirements.txt with the hashes for the required packages
-	pip-compile --generate-hashes 2> /dev/null
+	pip-compile -U --generate-hashes 2> /dev/null
 
 	# Removes psycopg from the list of packages to install
 	sed -i '/psycopg/{:a;N;/barman/!ba};/via barman/d' requirements.txt


### PR DESCRIPTION
This is to avoid having old dependencies that has security issues inside.

Closes #84 