### PR TITLE
ci: the global read-all permission was missing for workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ env:
   IMAGE_STAGING: "ghcr.io/${{ github.repository_owner }}/postgis-testing"
   IMAGE_RELEASE: "ghcr.io/${{ github.repository_owner }}/postgis"
 
+permissions: read-all
+
 jobs:
   generate-jobs:
     name: Generate Jobs

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -12,6 +12,8 @@ defaults:
   run:
     shell: 'bash -Eeuo pipefail -x {0}'
 
+permissions: read-all
+
 jobs:
   build:
     name: Run update script


### PR DESCRIPTION
Even when the workflows where having the proper permissions,
we forgot to add the read-all to the workflows, this was marking
some jobs as needing permissions when that wasn't true.

Closes #87 