### PR TITLE
Fix: Correctly tag architecture for ARM Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
         push: false
         load: true
         tags: ${{ env.TAGS }}
+        provenance: false
 
     - name: Dockle scan
       uses: erzz/dockle-action@v1
@@ -140,6 +141,7 @@ jobs:
         platforms: ${{ matrix.platforms }}
         push: true
         tags: ${{ env.TAGS }}
+        provenance: false
 
     - name: Create artifact
       run: |


### PR DESCRIPTION
I noticed that cnpg's postgis container for ARM is tagged as `unknown/unknown` in GHCR, which result in ImagePullBackOff error when we use postgis in ARM node.
Since [v4.0.0 of docker/build-push-action](https://github.com/docker/build-push-action/releases/tag/v4.0.0), provenance mode is on by default. By turning it off, we can correctly tag architecture for all architectures, including ARM.

This is my first time contributing to this repo, so if there is anything missing, please let me know.