### PR TITLE
chore: enable OCI artifact type for attestation manifests

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -61,6 +61,9 @@ target "postgis" {
     POSTGIS_MAJOR = postgisMajor
     BASE = "${getBaseImage(pgVersion, tgt, distro)}"
   }
+  output = [
+    "type=image,oci-mediatypes=true,oci-artifact=true",
+  ]
   attest = [
     "type=provenance,mode=max",
     "type=sbom"


### PR DESCRIPTION
BuildKit's default image exporter does not set `artifactType` or the OCI 1.1 Referrers `subject` backlink on attestation manifests. Setting `oci-artifact=true` on the image exporter adds both, so SBOM and provenance attestations become discoverable through the OCI Referrers API.

`oci-mediatypes=true` is redundant (BuildKit already defaults it to true when pushing to a registry, which is why the top-level index is already `application/vnd.oci.image.index.v1+json`) but kept for clarity.

Same fix as cloudnative-pg/cloudnative-pg#10601, mirroring cloudnative-pg/postgres-extensions-containers#198.

Closes #123