### PR TITLE
chore: expand account names in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cloudnative-pg/maintainers @NiccoloFei @jbattiato @litaocdl
+* @gbartolini @mnencia @leonardoce @fcanovai @NiccoloFei @litaocdl


### PR DESCRIPTION
Removed @jbattiato (erroneously added, 0 commits)

Closes #131